### PR TITLE
Handle another input format

### DIFF
--- a/pythonXdmfReader.py
+++ b/pythonXdmfReader.py
@@ -113,20 +113,27 @@ def ReadConnect(xdmfFilename):
    return connect
 
 def GetDataLocationAndPrecision(xdmfFilename, dataName):
+   def get(prop):
+      dataLocation = prop.text
+      data_prec = int(prop.get("Precision"))
+      dims = prop.get("Dimensions").split()
+      if len(dims)==1:
+         MemDimension = int(prop.get("Dimensions").split()[0])
+      else:
+         MemDimension = int(prop.get("Dimensions").split()[1])
+      return [dataLocation,data_prec,MemDimension]
+   
    tree = ET.parse(xdmfFilename)
    root = tree.getroot()
    for Property in root.findall('.//Attribute'):
       if Property.get("Name")==dataName:
          for prop in Property.findall('.//DataItem'):
             if prop.get("Format") in ['HDF','Binary']:
-               dataLocation = prop.text
-               data_prec = int(prop.get("Precision"))
-               dims = prop.get("Dimensions").split()
-               if len(dims)==1:
-                  MemDimension = int(prop.get("Dimensions").split()[0])
-               else:
-                  MemDimension = int(prop.get("Dimensions").split()[1])
-               return [dataLocation,data_prec,MemDimension]
+               return get(prop)
+            path = prop.get("Reference")
+            if path is not None:
+               ref = tree.xpath(path)[0]
+               return get(ref)
    raise NameError('%s not found in dataset' %(dataName))
 
 def ReadNdt(xdmfFilename):


### PR DESCRIPTION
Handle the case when the data file name is in a referenced element, for example:
```xml
<Domain>
  <DataItem NumberType="Float" Precision="8" Format="Binary" Dimensions="51 145068">sumatra-surface_v.bin</DataItem>
  ...
  <Grid ...>
    ...
    <Attribute Name="v" Center="Cell">
      <DataItem ...>
        <DataItem ...>...</DataItem>
        <DataItem Reference="/Xdmf/Domain/DataItem[1]"/>
      </DataItem>
    </Attribute>
    ...
  </Grid>
</Domain>
```